### PR TITLE
test: add Economic Models section (PR #3)

### DIFF
--- a/lectures/intro.md
+++ b/lectures/intro.md
@@ -23,6 +23,12 @@ Economics is the study of how societies allocate scarce resources.
 - **Opportunity cost**: The value of the next best alternative
 - **Supply and demand**: Market forces that determine prices
 
+## Economic Models
+
+Economic models are simplified representations of economic processes. They help us understand complex systems by focusing on key relationships.
+
+We use both theoretical and empirical approaches to build and test these models.
+
 ## Mathematical Example
 
 The production function:


### PR DESCRIPTION
This PR adds a new ## Economic Models section at position 1 (after Getting Started).

Testing v0.3.0 with Bug #1 and Bug #2 fixes:
- Bug #1 fix: Should detect Economic Models as ADDED (not MODIFIED)
- Bug #2 fix: Should insert at correct position (not position 0)

Expected result in Chinese translation:
- 6 sections total (was 5)
- Economic Models inserted at position 1
- All other sections in correct order