### PR TITLE
test: component-based reconstruction

### DIFF
--- a/lectures/intro.md
+++ b/lectures/intro.md
@@ -11,7 +11,7 @@ kernelspec:
 
 # Introduction to Economics
 
-This is a comprehensive test lecture for the translation sync action, demonstrating various types of changes.
+This is a simple test lecture for the translation sync action with minimal changes.
 
 ## Basic Concepts
 


### PR DESCRIPTION
Testing the new component-based document reconstruction approach.

**Change**: Single sentence in intro paragraph
- From: 'comprehensive test lecture...demonstrating various types of changes'
- To: 'simple test lecture...with minimal changes'

**Expected with NEW code (v0.5.0-dev)**:
✅ Intro paragraph translated
✅ All sections preserved unchanged
✅ Complete document structure maintained

**Previous bug (v0.4.3)**:
❌ All sections were deleted except the intro
❌ Only frontmatter + intro remained

This tests the fix from commit a899aea.