### PR TITLE
ci: add Malayalam (ml) sync workflow mirroring the fa harness

### DIFF
--- a/.github/workflows/sync-translations-ml.yml
+++ b/.github/workflows/sync-translations-ml.yml
@@ -1,0 +1,70 @@
+# Translation Sync — Malayalam
+#
+# Mirrors the production source-repo sync workflow (see
+# lecture-python-programming/.github/workflows/sync-translations-ml.yml)
+# so that a release is exercised through the same wiring the estate runs.
+#
+# HARNESS NOTE: like the review/rebase workflows on the target repos, this
+# tracks the published `@v0` tag rather than checking out the action and
+# building it with `uses: ./action`. The harness is meant to catch config
+# regressions as well as code regressions, and the local-build form never
+# exercises whether `@v0` resolves to the intended release — which is the
+# change the estate most often makes. This file previously pinned
+# `ref: v0.16.1` and built locally, so it silently retested a release six
+# versions behind what production was running.
+# See QuantEcon/action-translation#109.
+#
+# To validate UNRELEASED code, drive the CLI locally against this repo with a
+# built bundle — `uses:` cannot take an expression, so a workflow cannot
+# switch action versions dynamically.
+#
+# HARNESS-ONLY DIVERGENCE from the production template, kept deliberately:
+#   * the `test-translation` label trigger + `test-mode`, so a sync can be
+#     fired from an OPEN fixture PR without merging anything to main;
+#   * `target-repo` derived from ${{ github.repository }} so a fork of the
+#     harness points at its own targets.
+name: Translation Sync (Malayalam)
+
+on:
+  pull_request:
+    types: [closed, labeled]
+  issue_comment:
+    types: [created]
+
+jobs:
+  sync-translation-ml:
+    # Merged PR (production path) OR the `test-translation` label on an open PR
+    # (harness path) OR `\translate-resync` on a merged PR (production path).
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
+      (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'test-translation') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '\translate-resync'))
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+
+      - name: Determine mode
+        id: mode
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.action }}" == "labeled" ]]; then
+            echo "test-mode=true" >> $GITHUB_OUTPUT
+            echo "🧪 TEST mode — fired by the test-translation label on an open PR"
+          else
+            echo "test-mode=false" >> $GITHUB_OUTPUT
+            echo "🚀 PRODUCTION mode — merged PR or \translate-resync"
+          fi
+
+      - uses: QuantEcon/action-translation@v0
+        with:
+          mode: sync
+          target-repo: ${{ github.repository }}.ml
+          target-language: ml
+          source-language: en
+          docs-folder: '.'
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ secrets.QUANTECON_SERVICES_PAT }}
+          test-mode: ${{ steps.mode.outputs.test-mode }}


### PR DESCRIPTION
Wires the harness for the new `QuantEcon/test-translation-sync.ml` target repo, created via `translate setup` for the Malayalam test project (QuantEcon/action-translation#189, Phase 0). The workflow is `sync-translations-fa.yml` with only the language identifiers swapped (job id, target suffix, `target-language: ml`, titles) — verified no other diff. Same triggers as the fa harness: merged PR, the `test-translation` label on an open fixture PR, and `\translate-resync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)